### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server that 
 - **DOI lookup** - Find papers by their DOI
 - **Add documents** - Create new entries in your library
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/pallaprolus-mendeley-mcp).
+
 ## Prerequisites
 
 1. **Mendeley Account** - Sign up at [mendeley.com](https://www.mendeley.com/) (uses Elsevier authentication)


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/pallaprolus-mendeley-mcp).