### PR TITLE
Add document update support

### DIFF
--- a/src/mendeley_mcp/client.py
+++ b/src/mendeley_mcp/client.py
@@ -152,9 +152,7 @@ class MendeleyClient:
     def _auth_headers(self, accept: str | None = None) -> dict[str, str]:
         """Get authorization headers."""
         if not self.credentials.access_token:
-            raise ValueError(
-                "No access token available. Run 'mendeley-auth login' first."
-            )
+            raise ValueError("No access token available. Run 'mendeley-auth login' first.")
         headers = {
             "Authorization": f"Bearer {self.credentials.access_token}",
         }
@@ -169,6 +167,7 @@ class MendeleyClient:
 
         # Mendeley prefers HTTP Basic Auth
         import base64
+
         auth_str = f"{self.credentials.client_id}:{self.credentials.client_secret}"
         auth_bytes = base64.b64encode(auth_str.encode()).decode()
 
@@ -376,6 +375,26 @@ class MendeleyClient:
             "/documents",
             accept="application/vnd.mendeley-document.1+json",
             json=data,
+            headers={
+                "Content-Type": "application/vnd.mendeley-document.1+json",
+            },
+        )
+        return Document.from_api(response.json())
+
+    async def update_document(
+        self,
+        document_id: str,
+        **kwargs: Any,
+    ) -> Document:
+        """Update fields on an existing document in the library."""
+        if not kwargs:
+            raise ValueError("At least one field must be provided for update")
+
+        response = await self._request(
+            "PATCH",
+            f"/documents/{document_id}",
+            accept="application/vnd.mendeley-document.1+json",
+            json=kwargs,
             headers={
                 "Content-Type": "application/vnd.mendeley-document.1+json",
             },

--- a/src/mendeley_mcp/server.py
+++ b/src/mendeley_mcp/server.py
@@ -74,18 +74,42 @@ def format_document(doc: Document) -> dict[str, Any]:
     return {
         "id": doc.id,
         "title": doc.title,
-        "authors": [
-            f"{a.get('last_name', '')}, {a.get('first_name', '')}"
-            for a in doc.authors
-        ],
+        "authors": [f"{a.get('last_name', '')}, {a.get('first_name', '')}" for a in doc.authors],
         "year": doc.year,
         "type": doc.type,
         "source": doc.source,
-        "abstract": doc.abstract[:500] + "..." if doc.abstract and len(doc.abstract) > 500 else doc.abstract,
+        "abstract": doc.abstract[:500] + "..."
+        if doc.abstract and len(doc.abstract) > 500
+        else doc.abstract,
         "identifiers": doc.identifiers,
         "has_pdf": doc.file_attached,
         "citation": doc.format_citation(),
     }
+
+
+def parse_json_object(value: str | None, field_name: str) -> dict[str, Any] | None:
+    """Parse optional JSON object input for MCP clients with weak schemas."""
+    if not value:
+        return None
+    parsed = json.loads(value)
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{field_name} must be a JSON object")
+    return parsed
+
+
+def parse_authors_json(value: str | None) -> list[dict[str, str]] | None:
+    """Parse optional Mendeley authors JSON input."""
+    if not value:
+        return None
+    parsed = json.loads(value)
+    if not isinstance(parsed, list):
+        raise ValueError("authors_json must be a JSON array")
+    for author in parsed:
+        if not isinstance(author, dict):
+            raise ValueError("Each author must be a JSON object")
+        if "last_name" not in author:
+            raise ValueError("Each author must include last_name")
+    return parsed
 
 
 @mcp.tool()
@@ -237,18 +261,22 @@ async def mendeley_search_catalog(
         results = await client.search_catalog(query, limit=limit)
         formatted = []
         for item in results:
-            formatted.append({
-                "catalog_id": item.get("id"),
-                "title": item.get("title"),
-                "authors": [
-                    f"{a.get('last_name', '')}, {a.get('first_name', '')}"
-                    for a in item.get("authors", [])
-                ],
-                "year": item.get("year"),
-                "source": item.get("source"),
-                "identifiers": item.get("identifiers"),
-                "abstract": item.get("abstract", "")[:300] + "..." if item.get("abstract") else None,
-            })
+            formatted.append(
+                {
+                    "catalog_id": item.get("id"),
+                    "title": item.get("title"),
+                    "authors": [
+                        f"{a.get('last_name', '')}, {a.get('first_name', '')}"
+                        for a in item.get("authors", [])
+                    ],
+                    "year": item.get("year"),
+                    "source": item.get("source"),
+                    "identifiers": item.get("identifiers"),
+                    "abstract": item.get("abstract", "")[:300] + "..."
+                    if item.get("abstract")
+                    else None,
+                }
+            )
         return json.dumps(formatted, indent=2)
     except Exception as e:
         return json.dumps({"error": str(e)})
@@ -295,10 +323,12 @@ async def mendeley_add_document(
     title: str,
     doc_type: str = "journal",
     authors: list[dict[str, str]] | None = None,
+    authors_json: str | None = None,
     year: int | None = None,
     source: str | None = None,
     abstract: str | None = None,
     identifiers: dict[str, str] | None = None,
+    identifiers_json: str | None = None,
 ) -> str:
     """
     Add a new document to your Mendeley library.
@@ -307,10 +337,14 @@ async def mendeley_add_document(
         title: Document title (required)
         doc_type: Type - 'journal', 'book', 'conference_proceedings', etc.
         authors: List of author dicts with 'first_name' and 'last_name'
+        authors_json: JSON array of author objects, useful when clients cannot
+            pass nested authors. Example: [{"first_name":"Jun","last_name":"Liu"}]
         year: Publication year
         source: Journal/book name
         abstract: Document abstract
         identifiers: Dict with 'doi', 'pmid', 'isbn', etc.
+        identifiers_json: JSON object of identifiers, useful when clients cannot
+            pass nested identifiers.
 
     Returns:
         JSON object with the created document
@@ -318,19 +352,77 @@ async def mendeley_add_document(
     client = await get_client()
 
     kwargs: dict[str, Any] = {}
-    if authors:
-        kwargs["authors"] = authors
-    if year:
-        kwargs["year"] = year
-    if source:
-        kwargs["source"] = source
-    if abstract:
-        kwargs["abstract"] = abstract
-    if identifiers:
-        kwargs["identifiers"] = identifiers
 
     try:
+        parsed_authors = authors or parse_authors_json(authors_json)
+        parsed_identifiers = identifiers or parse_json_object(identifiers_json, "identifiers_json")
+        if parsed_authors:
+            kwargs["authors"] = parsed_authors
+        if year:
+            kwargs["year"] = year
+        if source:
+            kwargs["source"] = source
+        if abstract:
+            kwargs["abstract"] = abstract
+        if parsed_identifiers:
+            kwargs["identifiers"] = parsed_identifiers
+
         doc = await client.add_document(title=title, doc_type=doc_type, **kwargs)
+        return json.dumps(format_document(doc), indent=2)
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+async def mendeley_update_document(
+    document_id: str,
+    title: str | None = None,
+    doc_type: str | None = None,
+    authors_json: str | None = None,
+    year: int | None = None,
+    source: str | None = None,
+    abstract: str | None = None,
+    identifiers_json: str | None = None,
+) -> str:
+    """
+    Update an existing document in your Mendeley library.
+
+    Args:
+        document_id: Existing Mendeley document ID
+        title: New document title
+        doc_type: New Mendeley document type, e.g. 'journal'
+        authors_json: JSON array of author objects. Example:
+            [{"first_name":"Jun","last_name":"Liu"}]
+        year: Publication year
+        source: Journal/book name
+        abstract: Document abstract
+        identifiers_json: JSON object of identifiers, e.g. {"doi":"10..."}
+
+    Returns:
+        JSON object with the updated document
+    """
+    client = await get_client()
+
+    try:
+        kwargs: dict[str, Any] = {}
+        if title is not None:
+            kwargs["title"] = title
+        if doc_type is not None:
+            kwargs["type"] = doc_type
+        parsed_authors = parse_authors_json(authors_json)
+        if parsed_authors is not None:
+            kwargs["authors"] = parsed_authors
+        if year is not None:
+            kwargs["year"] = year
+        if source is not None:
+            kwargs["source"] = source
+        if abstract is not None:
+            kwargs["abstract"] = abstract
+        parsed_identifiers = parse_json_object(identifiers_json, "identifiers_json")
+        if parsed_identifiers is not None:
+            kwargs["identifiers"] = parsed_identifiers
+
+        doc = await client.update_document(document_id=document_id, **kwargs)
         return json.dumps(format_document(doc), indent=2)
     except Exception as e:
         return json.dumps({"error": str(e)})
@@ -354,10 +446,7 @@ async def get_all_folders() -> str:
     client = await get_client()
     try:
         folders = await client.get_folders()
-        results = [
-            {"id": f.id, "name": f.name, "parent_id": f.parent_id}
-            for f in folders
-        ]
+        results = [{"id": f.id, "name": f.name, "parent_id": f.parent_id} for f in folders]
         return json.dumps(results, indent=2)
     except Exception as e:
         return json.dumps({"error": str(e)})

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,6 +3,7 @@
 import pytest
 
 from mendeley_mcp.client import Document, Folder, MendeleyCredentials
+from mendeley_mcp.server import parse_authors_json, parse_json_object
 
 
 class TestMendeleyCredentials:
@@ -139,3 +140,34 @@ class TestFolder:
 
         assert folder.id == "folder-root"
         assert folder.parent_id is None
+
+
+class TestJsonInputs:
+    """Tests for JSON string helper inputs exposed by MCP tools."""
+
+    def test_parse_authors_json(self):
+        """Test parsing authors from a JSON string."""
+        authors = parse_authors_json('[{"first_name":"Ada","last_name":"Lovelace"}]')
+
+        assert authors == [{"first_name": "Ada", "last_name": "Lovelace"}]
+
+    def test_parse_authors_json_requires_array(self):
+        """Test rejecting non-array author JSON."""
+        with pytest.raises(ValueError, match="JSON array"):
+            parse_authors_json('{"first_name":"Ada","last_name":"Lovelace"}')
+
+    def test_parse_authors_json_requires_last_name(self):
+        """Test rejecting authors without a last name."""
+        with pytest.raises(ValueError, match="last_name"):
+            parse_authors_json('[{"first_name":"Ada"}]')
+
+    def test_parse_json_object(self):
+        """Test parsing a JSON object input."""
+        identifiers = parse_json_object('{"doi":"10.1234/test"}', "identifiers_json")
+
+        assert identifiers == {"doi": "10.1234/test"}
+
+    def test_parse_json_object_rejects_array(self):
+        """Test rejecting non-object JSON."""
+        with pytest.raises(ValueError, match="JSON object"):
+            parse_json_object('["doi"]', "identifiers_json")


### PR DESCRIPTION
## Summary
- Add a Mendeley API client method for PATCH-based document updates.
- Expose a new `mendeley_update_document` MCP tool so existing library records can be edited without creating duplicates.
- Add `authors_json` and `identifiers_json` string inputs for add/update flows to support MCP clients that cannot reliably pass nested list/dict parameters.

## Verification
- `uv run ruff check src/mendeley_mcp/client.py src/mendeley_mcp/server.py tests/test_client.py`
- `uv run pytest -q`