### PR TITLE
Migrate to MCP Python SDK v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,5 +509,5 @@ This project is not affiliated with, endorsed by, or sponsored by Mendeley or El
 ## Acknowledgments
 
 - [Model Context Protocol](https://modelcontextprotocol.io/) by Anthropic
-- [FastMCP](https://github.com/jlowin/fastmcp) Python framework
+- [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk)
 - [Mendeley API](https://dev.mendeley.com/) documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp>=1.19.0",
+    "mcp>=2.0.0,<3.0.0",
     "httpx>=0.27.0",
-    "pydantic>=2.0.0",
     "keyring>=25.0.0",
     "click>=8.0.0",
     "pypdf>=4.0.0",

--- a/src/mendeley_mcp/__init__.py
+++ b/src/mendeley_mcp/__init__.py
@@ -5,10 +5,10 @@ An MCP server for integrating Mendeley reference manager with LLM applications.
 """
 
 from .client import Document, Folder, MendeleyClient, MendeleyCredentials
-from .server import mcp
+from .server import __version__, mcp
 
-__version__ = "0.3.0"
 __all__ = [
+    "__version__",
     "mcp",
     "MendeleyClient",
     "MendeleyCredentials",

--- a/src/mendeley_mcp/server.py
+++ b/src/mendeley_mcp/server.py
@@ -13,6 +13,8 @@ import json
 import os
 import re
 import sys
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
 from typing import Any
 
 import httpx
@@ -29,8 +31,14 @@ from pypdf import PdfReader
 from .auth import load_credentials
 from .client import Document, Folder, MendeleyClient, MendeleyCredentials
 
-# Initialize the MCP server
-mcp = MCPServer("mendeley")
+try:
+    __version__ = package_version("mendeley-mcp")
+except PackageNotFoundError:  # running from a source tree with no install
+    __version__ = "0.0.0+unknown"
+
+# Initialize the MCP server. The version is what clients report in bug
+# reports, so it has to be this package's version rather than the SDK's.
+mcp = MCPServer("mendeley", version=__version__)
 
 # Embedded files are base64-encoded into the tool result and therefore into the
 # client's context window, so oversized files are reported but not embedded.

--- a/src/mendeley_mcp/server.py
+++ b/src/mendeley_mcp/server.py
@@ -16,7 +16,7 @@ import sys
 from typing import Any
 
 import httpx
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from mcp.types import (
     BlobResourceContents,
     CallToolResult,
@@ -24,14 +24,13 @@ from mcp.types import (
     EmbeddedResource,
     TextContent,
 )
-from pydantic import AnyUrl
 from pypdf import PdfReader
 
 from .auth import load_credentials
 from .client import Document, Folder, MendeleyClient, MendeleyCredentials
 
 # Initialize the MCP server
-mcp = FastMCP("mendeley")
+mcp = MCPServer("mendeley")
 
 # Embedded files are base64-encoded into the tool result and therefore into the
 # client's context window, so oversized files are reported but not embedded.
@@ -184,8 +183,8 @@ def build_tool_result(
 
     return CallToolResult(
         content=content,
-        structuredContent=structured_content,
-        isError=is_error,
+        structured_content=structured_content,
+        is_error=is_error,
     )
 
 
@@ -970,8 +969,8 @@ async def mendeley_get_file_content(
     embedded_resource = EmbeddedResource(
         type="resource",
         resource=BlobResourceContents(
-            uri=AnyUrl(uri),
-            mimeType="application/pdf",
+            uri=uri,
+            mime_type="application/pdf",
             blob=base64.b64encode(file_content).decode("ascii"),
         ),
     )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from mcp.server.mcpserver import MCPServer
 
 import mendeley_mcp.server as server
 from mendeley_mcp.client import Document, Folder
@@ -20,6 +21,11 @@ pytestmark = pytest.mark.anyio
 def anyio_backend() -> str:
     """Run async tool tests only on asyncio to match the project runtime."""
     return "asyncio"
+
+
+def test_server_uses_mcp_sdk_v2_server() -> None:
+    """The application server should use the MCP SDK v2 server class."""
+    assert isinstance(server.mcp, MCPServer)
 
 
 @pytest.fixture
@@ -699,8 +705,8 @@ def test_mendeley_get_file_content_returns_embedded_pdf(monkeypatch):
 
     result = asyncio.run(server.mendeley_get_file_content("catalog-123"))
 
-    assert result.isError is False
-    assert result.structuredContent == {
+    assert result.is_error is False
+    assert result.structured_content == {
         "document_id": "catalog-123",
         "title": "Catalog Paper",
         "year": 2024,
@@ -714,7 +720,7 @@ def test_mendeley_get_file_content_returns_embedded_pdf(monkeypatch):
     }
     assert result.content[0].type == "text"
     assert result.content[1].type == "resource"
-    assert result.content[1].resource.mimeType == "application/pdf"
+    assert result.content[1].resource.mime_type == "application/pdf"
     assert (
         str(result.content[1].resource.uri)
         == "mendeley://documents/catalog-123/file/Catalog_Paper.pdf"
@@ -760,8 +766,8 @@ def test_mendeley_get_file_content_skips_embedding_oversized_files(monkeypatch):
 
     result = asyncio.run(server.mendeley_get_file_content("doc-huge"))
 
-    assert result.isError is False
-    assert result.structuredContent == {
+    assert result.is_error is False
+    assert result.structured_content == {
         "document_id": "doc-huge",
         "title": "Huge Paper",
         "year": 2023,
@@ -786,8 +792,8 @@ def test_mendeley_get_file_content_reports_missing_file(monkeypatch):
 
     result = asyncio.run(server.mendeley_get_file_content("doc-456"))
 
-    assert result.isError is False
-    assert result.structuredContent == {
+    assert result.is_error is False
+    assert result.structured_content == {
         "document_id": "doc-456",
         "title": "Library Paper",
         "year": 2023,
@@ -882,13 +888,13 @@ def test_mendeley_get_document_text_returns_extracted_text(monkeypatch):
 
     result = asyncio.run(server.mendeley_get_document_text("doc-text"))
 
-    assert result.isError is False
-    assert result.structuredContent is not None
-    assert result.structuredContent["text_available"] is True
-    assert result.structuredContent["file_available"] is True
-    assert result.structuredContent["page_count"] == 1
-    assert result.structuredContent["truncated"] is False
-    assert result.structuredContent["char_count"] > 0
+    assert result.is_error is False
+    assert result.structured_content is not None
+    assert result.structured_content["text_available"] is True
+    assert result.structured_content["file_available"] is True
+    assert result.structured_content["page_count"] == 1
+    assert result.structured_content["truncated"] is False
+    assert result.structured_content["char_count"] > 0
     assert len(result.content) == 2
     assert result.content[0].type == "text"
     assert result.content[1].type == "text"
@@ -905,10 +911,10 @@ def test_mendeley_get_document_text_reports_scanned_pdf(monkeypatch):
 
     result = asyncio.run(server.mendeley_get_document_text("doc-text"))
 
-    assert result.isError is False
-    assert result.structuredContent is not None
-    assert result.structuredContent["text_available"] is False
-    assert result.structuredContent["file_available"] is True
+    assert result.is_error is False
+    assert result.structured_content is not None
+    assert result.structured_content["text_available"] is False
+    assert result.structured_content["file_available"] is True
     assert len(result.content) == 1
     assert "no extractable text layer" in result.content[0].text
 
@@ -924,9 +930,9 @@ def test_mendeley_get_document_text_truncates_long_text(monkeypatch):
 
     result = asyncio.run(server.mendeley_get_document_text("doc-text"))
 
-    assert result.isError is False
-    assert result.structuredContent is not None
-    assert result.structuredContent["truncated"] is True
+    assert result.is_error is False
+    assert result.structured_content is not None
+    assert result.structured_content["truncated"] is True
     assert len(result.content) == 2
     assert len(result.content[1].text) == 10
     assert "truncated" in result.content[0].text
@@ -942,9 +948,9 @@ def test_mendeley_get_document_text_reports_missing_file(monkeypatch):
 
     result = asyncio.run(server.mendeley_get_document_text("doc-456"))
 
-    assert result.isError is False
-    assert result.structuredContent is not None
-    assert result.structuredContent["text_available"] is False
-    assert result.structuredContent["file_available"] is False
+    assert result.is_error is False
+    assert result.structured_content is not None
+    assert result.structured_content["text_available"] is False
+    assert result.structured_content["file_available"] is False
     assert len(result.content) == 1
     assert "No attached file is available" in result.content[0].text

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -954,3 +954,16 @@ def test_mendeley_get_document_text_reports_missing_file(monkeypatch):
     assert result.structured_content["file_available"] is False
     assert len(result.content) == 1
     assert "No attached file is available" in result.content[0].text
+
+
+def test_server_reports_the_package_version():
+    """serverInfo must carry this package's version, not the SDK's.
+
+    Under the v1 SDK this field defaulted to the SDK version, so a bug report
+    quoting it named the wrong thing. It is also read from installed metadata
+    rather than hard-coded, so it cannot drift from pyproject.
+    """
+    from importlib.metadata import version as package_version
+
+    assert server.__version__ == package_version("mendeley-mcp")
+    assert server.mcp.version == server.__version__


### PR DESCRIPTION
## Summary
- Migrate the server from FastMCP to the MCP Python SDK v2 MCPServer API.
- Update v2 snake_case result fields and string resource URIs.
- Add regression coverage and update the SDK acknowledgment.

## Context
This addresses issue #7's reported mcp.server.fastmcp import failure by following the official [MCP Python SDK v1-to-v2 migration guide](https://py.sdk.modelcontextprotocol.io/migration/).

## Validation
- pytest -q: 74 passed
- ruff check src tests: passed
- mypy src/mendeley_mcp: passed