### PR TITLE
Pin MCP SDK dependency below v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp>=1.19.0",
+    "mcp>=1.19.0,<2",
     "httpx>=0.27.0",
     "pydantic>=2.0.0",
     "keyring>=25.0.0",


### PR DESCRIPTION
## Summary
- Pin the MCP Python SDK to the maintained v1 line with mcp>=1.19.0,<2.
- Prevent installs from resolving the incompatible MCP SDK v2 API.

## Context
This addresses issue #7's reported mcp.server.fastmcp installation failure by applying the v1 compatibility path.

## Validation
- pytest -q: 73 passed
- ruff check src tests: passed
- mypy src/mendeley_mcp: passed