### PR TITLE
ci: watch the published artifact, not just the repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Dependencies are declared with lower bounds and no lockfile, so the versions
+  # a build resolves drift on their own between commits. Running on a schedule
+  # catches a dependency release that breaks the suite while main is idle,
+  # instead of the next person to push discovering it.
+  schedule:
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/published-smoke.yml
+++ b/.github/workflows/published-smoke.yml
@@ -1,0 +1,91 @@
+name: Published Artifact Smoke Test
+
+# CI runs on push and pull_request, so it only ever tests the repository. It
+# says nothing about the package already on PyPI, which keeps being installed
+# against dependency versions that did not exist when it was released.
+#
+# That gap is not hypothetical: MCP Python SDK 2.0.0 removed
+# `mcp.server.fastmcp`, so from 2026-07-28 every fresh install of 0.4.0 failed
+# at import while CI stayed green, because nothing had been pushed since June.
+# It surfaced four weeks later as a bug report from a user (#7).
+#
+# This job installs the *published* artifact from PyPI on a schedule, with no
+# repository code on the path, and fails if a fresh install can no longer be
+# imported. A failed scheduled run notifies the repository owner, which is the
+# signal that was missing.
+
+on:
+  schedule:
+    # Daily. Dependency releases are the trigger being watched for, and they
+    # can land any day.
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to smoke test (default: latest on PyPI)'
+        required: false
+        type: string
+
+jobs:
+  smoke:
+    name: Fresh install (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The declared floor and the newest supported version. A resolver
+        # difference between them is itself worth catching.
+        python-version: ['3.10', '3.12']
+
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install the published package into a clean environment
+        run: |
+          python -m venv /tmp/smoke
+          /tmp/smoke/bin/python -m pip install --quiet --upgrade pip
+          spec="mendeley-mcp"
+          if [ -n "${{ inputs.version }}" ]; then
+            spec="mendeley-mcp==${{ inputs.version }}"
+          fi
+          echo "Installing $spec from PyPI"
+          /tmp/smoke/bin/python -m pip install --no-cache-dir "$spec"
+
+      - name: Report what actually resolved
+        run: /tmp/smoke/bin/python -m pip list
+
+      - name: Import the server and the auth CLI
+        run: |
+          /tmp/smoke/bin/python - <<'PY'
+          import asyncio
+          import importlib.metadata as md
+
+          print("mendeley-mcp", md.version("mendeley-mcp"), "| mcp", md.version("mcp"))
+
+          # The import that broke: server.py imports the SDK at module scope, so
+          # an incompatible SDK fails here rather than at first tool call.
+          import mendeley_mcp  # noqa: F401
+          from mendeley_mcp.auth import cli  # noqa: F401
+          from mendeley_mcp.server import mcp
+
+          # Registration exercises the SDK's decorator surface, which a bare
+          # import does not. Deliberately not asserting an exact count, so the
+          # check does not need editing every time a tool is added.
+          tools = asyncio.run(mcp.list_tools())
+          resources = asyncio.run(mcp.list_resources())
+          print(f"registered {len(tools)} tools, {len(resources)} resources")
+          assert tools, "no tools registered"
+          assert resources, "no resources registered"
+          print("import and registration OK")
+          PY
+
+      - name: Console entry points are installed and runnable
+        run: |
+          # mendeley-mcp itself serves on stdio and would block, so only its
+          # presence is checked here; mendeley-auth is the path from #7.
+          test -x /tmp/smoke/bin/mendeley-mcp
+          /tmp/smoke/bin/mendeley-auth --help > /dev/null
+          echo "entry points OK"


### PR DESCRIPTION
## Why

CI only runs on `push` and `pull_request`, so it exclusively tests *the repository*. It says nothing about the package already on PyPI — which keeps getting installed against dependency versions that did not exist when it was released.

That is exactly how 0.4.0 stayed broken for four weeks. MCP Python SDK 2.0.0 removed `mcp.server.fastmcp` on 2026-07-28, so every fresh install failed at import from that day forward, while CI stayed green because nothing had been pushed to main since June. It surfaced as a user bug report (#7) rather than a failing build.

The pin in 0.4.1 fixed *that* breakage. This fixes the reason nobody noticed.

## What

- **`published-smoke.yml`** (new, daily): installs the published artifact from PyPI into a clean venv with no repository code on the path, imports the server and auth CLI, and lists tools and resources. A failed scheduled run notifies the repo owner — the signal that was missing. Runs on 3.10 and 3.12; `workflow_dispatch` accepts a specific version.
- **`ci.yml`**: adds a weekly schedule and `workflow_dispatch`. Dependencies are lower-bounded with no lockfile, so resolved versions drift between commits.

## Verification

Ran the smoke body against both releases in a clean `python:3.12-slim` container:

| Version | Result |
|---|---|
| `0.4.0` | **exit 1** — `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` |
| `0.4.1` | exit 0 — `18 tools, 2 resources`, entry points OK |

So this check would have caught the outage on 2026-07-28 instead of four weeks later.

## Deliberately not included

Upper bounds on the other dependencies (`httpx`, `pydantic`, `keyring`, `click`, `pypdf`) — all lower-bounded today, so the same class of failure is still latent. That is a considered change and belongs in its own PR, not bundled with detection.